### PR TITLE
use existing secret instead of secret: section

### DIFF
--- a/charts/librephotos/templates/deploymentBackend.yaml
+++ b/charts/librephotos/templates/deploymentBackend.yaml
@@ -82,8 +82,13 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ $resourceName }}-secrets"
+          {{- if .Values.existingSecret }}
+            - secretRef:
+                name: "{{ .Values.existingSecret }}"
+          {{ else }}
             - secretRef:
                 name: "{{ $resourceName }}-creds"
+          {{- end }}
           {{- range $secretName := $localTree.externalSecrets }}
             - secretRef:
                 name: {{ $secretName | quote }}

--- a/charts/librephotos/templates/deploymentBackend.yaml
+++ b/charts/librephotos/templates/deploymentBackend.yaml
@@ -82,7 +82,8 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ $resourceName }}-secrets"
-          {{- if .Values.existingSecret }}
+            - secretRef:
+               name: {{ if .Values.existingSecret -}} {{ .Values.existingSecret | quote }} {{- else }} "{{ $resourceName }}-creds" {{- end }}
             - secretRef:
                 name: "{{ .Values.existingSecret }}"
           {{ else }}

--- a/charts/librephotos/templates/secretAuth.yaml
+++ b/charts/librephotos/templates/secretAuth.yaml
@@ -1,4 +1,4 @@
-{{- if !$values.secret.existingSecret }}
+{{- if .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/librephotos/templates/secretAuth.yaml
+++ b/charts/librephotos/templates/secretAuth.yaml
@@ -1,3 +1,4 @@
+{{- if !$values.secret.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 stringData:
   {{- toYaml .Values.secret | nindent 2 }}
+{{- end }}

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -147,8 +147,10 @@ secret:
   ADMIN_USERNAME: "admin"
   ADMIN_PASSWORD: "password"
   MAPBOX_API_KEY: ""
-  existingSecret: false
-  # instead use an existingSecret: "librephotos-creds"
+
+# instead use an existingSecret: "librephotos-creds"
+existingSecret: false
+
 cronjob:
   # -- Create a native kubernetes cronjob, using roles to access kubernetes exec and execute the python through a third party container. This is an Antipattern! but the only way, till another exists
   type: native

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -148,7 +148,7 @@ secret:
   ADMIN_PASSWORD: "password"
   MAPBOX_API_KEY: ""
 
-# instead use an existingSecret: "librephotos-creds"
+# -- instead of creating and using the default secret. Name a secret in this variable
 existingSecret: false
 
 cronjob:

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -147,7 +147,8 @@ secret:
   ADMIN_USERNAME: "admin"
   ADMIN_PASSWORD: "password"
   MAPBOX_API_KEY: ""
-
+  existingSecret: false
+  # instead use an existingSecret: "librephotos-creds"
 cronjob:
   # -- Create a native kubernetes cronjob, using roles to access kubernetes exec and execute the python through a third party container. This is an Antipattern! but the only way, till another exists
   type: native


### PR DESCRIPTION
this would allow me to skip creation of the secret and just use a secret i previously created with kubeseal. this would populate the secret with a "existingSecret: false" (i think you would prefere that change over changing the structure within the secret: )

untested so far - but happy to test and report back once you published