### PR TITLE
fix pvc name

### DIFF
--- a/charts/zwave-js-ui/templates/pvc.yaml
+++ b/charts/zwave-js-ui/templates/pvc.yaml
@@ -3,7 +3,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "zwave-js-ui.fullname" . }}-zwave-js-ui
+  name: {{ template "zwave-js-ui.fullname" . }}-store
   labels:
     app.kubernetes.io/name: {{ include "zwave-js-ui.name" . }}
     helm.sh/chart: {{ include "zwave-js-ui.chart" . }}


### PR DESCRIPTION
The autogenerated PVC name doesn't match the PVC name in the deployment.
This PR should fix this.