### PR TITLE
Add zwave-js-ui service annotation templating

### DIFF
--- a/charts/zwave-js-ui/templates/service.yaml
+++ b/charts/zwave-js-ui/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "zwave-js-ui.fullname" . }}
   labels:
     {{- include "zwave-js-ui.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/zwave-js-ui/values.yaml
+++ b/charts/zwave-js-ui/values.yaml
@@ -53,6 +53,7 @@ ports:
 service:
   type: ClusterIP
   port: 8091  
+  annotations: {}
 
 # -- Setting default strategy, to avoid running 2 containers with one stick
 strategy:


### PR DESCRIPTION
Add optional annotations for service.

I personally need this for `external-dns.alpha.kubernetes.io/hostname`, but this could be used for anything...