### PR TITLE
Adds more extensive options for svc type LoadBalancer for the zwave ui chart

### DIFF
--- a/charts/zwave-js-ui/templates/service.yaml
+++ b/charts/zwave-js-ui/templates/service.yaml
@@ -9,7 +9,23 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+{{- else if eq .Values.service.type "LoadBalancer" }}
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     {{- with .Values.ports.ui }}
     - port: {{ .servicePort }}


### PR DESCRIPTION
LoadBalancer type allows additional values for loadBalancerIP (setting the desired LB IP) as well as externalTrafficPolicy.