### PR TITLE
mosquitto: add ability to set consistent clusterIP

### DIFF
--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}


### PR DESCRIPTION
This could be useful to have it consistent if the clusterIP to reach mosquitto is used in MQTT clients.